### PR TITLE
Updated CDN link for flags

### DIFF
--- a/src/_data/accessories/flags.js
+++ b/src/_data/accessories/flags.js
@@ -13,7 +13,7 @@ module.exports = [
       return {
         name: e.label,
         type: "remote",
-        src: `https://twemoji.maxcdn.com/v/latest/72x72/${e.hexcode.toLowerCase()}.png`,
+        src: `https://cdnjs.cloudflare.com/ajax/libs/twemoji/15.1.0/72x72/${e.hexcode.toLowerCase()}.png`,
       }
     }),
 ]


### PR DESCRIPTION
Looks like Maxcdn, the cdn that hosts the flags has shut down (https://github.com/twitter/twemoji/issues/580), so the flags 404 now

<img width="345" alt="image" src="https://github.com/user-attachments/assets/4200b7ab-d10a-4628-9255-c948c17bce79">

Luckily cdnjs has a hosted version that we can use instead, so this PR just swaps it out so the flags can work again